### PR TITLE
Add delete_currency_conversions task

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,24 @@ Use the `coin_payment_paid` method
       end
     end
 
+### Delete old CurrencyConversion data
+
+Every time the payment processor is run, several rows are inserted into the
+database to record the value of the coin at a given instance in time. Over time,
+your application will accumulate historical currency conversion data and you may
+want to clear it out:
+
+```
+rake cryptocoin_payable:delete_currency_conversions
+```
+
+By default, it will delete any data older than 1 month. You can configure this
+using an env variable:
+
+```
+DELETE_BEFORE=2017-12-15 rake cryptocoin_payable:delete_currency_conversions
+```
+
 ### Comp a payment
 
 This will bypass the payment, set the state to comped and call back to your app that the payment has been processed.

--- a/lib/cryptocoin_payable/commands/pricing_processor.rb
+++ b/lib/cryptocoin_payable/commands/pricing_processor.rb
@@ -4,6 +4,10 @@ module CryptocoinPayable
       new.perform
     end
 
+    def self.delete_currency_conversions(time_ago)
+      new.delete_currency_conversions(time_ago)
+    end
+
     def perform
       rates = CurrencyConversion.coin_types.map do |coin_pair|
         coin_type = coin_pair[0].to_sym
@@ -26,6 +30,12 @@ module CryptocoinPayable
           coin_conversion: rates[payment.coin_type.to_sym].price,
         )
       end
+    end
+
+    def delete_currency_conversions(time_ago)
+      last_id = CurrencyConversion.last.id
+      time = time_ago || 1.month.ago
+      CurrencyConversion.where('created_at < ? AND id != ?', time, last_id).delete_all
     end
   end
 end

--- a/lib/cryptocoin_payable/commands/pricing_processor.rb
+++ b/lib/cryptocoin_payable/commands/pricing_processor.rb
@@ -33,6 +33,8 @@ module CryptocoinPayable
     end
 
     def delete_currency_conversions(time_ago)
+      # Makes sure to keep at least one record in the db since other areas of
+      # the gem assume the existence of at least one record.
       last_id = CurrencyConversion.last.id
       time = time_ago || 1.month.ago
       CurrencyConversion.where('created_at < ? AND id != ?', time, last_id).delete_all

--- a/lib/cryptocoin_payable/tasks.rb
+++ b/lib/cryptocoin_payable/tasks.rb
@@ -8,7 +8,12 @@ namespace :cryptocoin_payable do
     CryptocoinPayable::PricingProcessor.perform
   end
 
-  desc 'Connect to HelloBlock.io and process payments'
+  desc 'Delete old CurrencyConversion data (will delete last month by default)'
+  task :delete_currency_conversions => :environment do
+    CryptocoinPayable::PricingProcessor.delete_currency_conversions(ENV['DELETE_BEFORE'])
+  end
+
+  desc 'Get transactions from external API and process payments'
   task :process_payments => :environment do
     CryptocoinPayable::PaymentProcessor.perform
   end


### PR DESCRIPTION
@Sailias I just wanted your opinion on this before I merge. I wanted to double check that it's intentional that the gem stores CurrencyConversions even though it only ever uses the most recent one? I assume this is for record keeping reasons. I decided to add a task to delete old ones instead of just fixing the feature/bug of CurrencyConversions accumulating over time.

Some context on this: my app has reached its database row limit on Heroku so I need to either upgrade or clear the old currency conversion data.