### PR TITLE
[Fix] installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ And then execute:
 
     $ bundle
 
-    $ rails g coin_payable:install
+    $ rails g cryptocoin_payable:install
 
     $ bundle exec rake db:migrate
 
     $ populate coin_payable.rb (see below)
 
-    $ bundle exec rake coin_payable:process_prices (see below)
+    $ bundle exec rake cryptocoin_payable:process_prices (see below)
 
 ## Uninstall
 
@@ -94,6 +94,8 @@ A BIP32 MPK in "Extended Key" format used when configuring bitcoin payments (see
 
 Public net starts with: xpub
 Testnet starts with: tpub
+
+* Obtain your BIP32 MPK from http://bip32.org/
 
 ### Adding it to your model
 


### PR DESCRIPTION
The current installation instructions result in errors such as: 
<img width="827" alt="screen shot 2018-01-20 at 4 32 29 pm" src="https://user-images.githubusercontent.com/935049/35188575-bf3dd86a-fe05-11e7-8001-5d90015779ae.png">

Fix:
- Updated instructions from `coin_payable:..` to `cryptocoin_payable:...`

Unrelated improvement:
- Added a resource obtaining a BIP32 MPK