### PR TITLE
Remove mnemonic requirement for eth

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ config/initializers/coin_payable.rb
 
       config.configure_btc do |btc_config|
         btc_config.node_path = 'm/0/'
-        btc_config.master_public_key = 'tpubD6NzVbkrYhZ4X3cxCktWVsVvMDd35JbNdhzZxb1aeDCG7LfN6KbcDQsqiyJHMEQGJURRgdxGbFBBF32Brwb2LsfpE2jQfCZKwzNBBMosjfm'
+        btc_config.master_public_key = 'tpub...'
 
         # Defaults to 3 confirmations.
         # btc_config.confirmations = 3
@@ -73,8 +73,7 @@ config/initializers/coin_payable.rb
         # Defaults to 12 confirmations.
         # eth_config.confirmations = 12
 
-        # NOTE: Avoid committing your mnemonic to source.
-        eth_config.mnemonic = ENV['BITCOIN_PAYABLE_ETH_MNEMONIC']
+        eth_config.master_public_key = 'tpub...'
       end
     end
 

--- a/lib/cryptocoin_payable/adapters/ethereum.rb
+++ b/lib/cryptocoin_payable/adapters/ethereum.rb
@@ -23,14 +23,13 @@ module CryptocoinPayable
       end
 
       def self.create_address(id)
-        mnemonic = CryptocoinPayable.configuration.eth.mnemonic
+        key = CryptocoinPayable.configuration.eth.master_public_key
 
-        raise 'mnemonic is required' unless mnemonic
+        raise 'master_public_key is required' unless key
 
-        master = MoneyTree::Master.new(seed_hex: ::Bitcoin::Trezor::Mnemonic.to_seed(mnemonic))
-        node = master.node_for_path("m/44'/60'/0'/0/#{id}")
-        key = Eth::Key.new(priv: node.private_key.to_hex)
-        key.address
+        master = MoneyTree::Node.from_bip32(key)
+        node = master.node_for_path(id.to_s)
+        Eth::Utils.public_key_to_address(node.public_key.uncompressed.to_hex)
       end
 
       private_class_method def self.adapter_domain

--- a/lib/cryptocoin_payable/config.rb
+++ b/lib/cryptocoin_payable/config.rb
@@ -49,7 +49,7 @@ module CryptocoinPayable
     end
 
     class EthConfiguration < CoinConfiguration
-      attr_accessor :mnemonic, :chain_id
+      attr_accessor :master_public_key, :chain_id
 
       def confirmations
         @confirmations ||= 12

--- a/spec/dummy/config/initializers/cryptocoin_payable.rb
+++ b/spec/dummy/config/initializers/cryptocoin_payable.rb
@@ -16,11 +16,5 @@ CryptocoinPayable.configure do |config|
     # 4: Rinkeby, the public Geth Ethereum testnet
     # See https://ethereum.stackexchange.com/a/17101/26695
     # eth_config.chain_id = 1
-
-    # NOTE: This should come from an env variable. Do not commit your real
-    # mnemonic to source.
-    eth_config.mnemonic = 'welcome public fly glance vacant pave hazard list ' +
-      'report gift wrestle space offer shove width top enough canvas relief ' +
-      'impose define armed over state'
   end
 end


### PR DESCRIPTION
Addresses https://github.com/Sailias/cryptocoin_payable/issues/3

I found one way to generate Ethereum addresses without relying on the mnemonic / private key. I had to switch to using BIP32 derivation and use `.node_for_path()` without the full derivation path. I'm honestly not sure why the method for computing these is different from the Bitcoin case but the generated addresses seem to match https://iancoleman.io/bip39/