### PR TITLE
Catch StandardError instead of EOFError

### DIFF
--- a/lib/cryptocoin_payable/adapters/coin.rb
+++ b/lib/cryptocoin_payable/adapters/coin.rb
@@ -55,7 +55,7 @@ module CryptocoinPayable
         amount = begin
           response = get_request("https://api.coinbase.com/v2/prices/#{coin_symbol}-#{CryptocoinPayable.configuration.currency.to_s.upcase}/spot")
           JSON.parse(response.body)['data']['amount'].to_f
-        rescue EOFError
+        rescue StandardError
           response = get_request("https://api.gemini.com/v1/pubticker/#{coin_symbol}#{CryptocoinPayable.configuration.currency.to_s.upcase}")
           JSON.parse(response.body)['last'].to_f
         end


### PR DESCRIPTION
In some rare cases, the endpoint returns HTML instead of JSON due to a Cloudflare 502 Bad Gateway error and the `JSON.parse` call fails. Its probably better to just catch the more general StandardError.